### PR TITLE
Set Current Limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,76 @@
-# moveit_twist_controller
-Direct end-effector control using a joystick based on the moveit inverse kinematics interface.
-Requires a [ros_control](http://wiki.ros.org/ros_control) joint position interface.
+# MoveIt Twist Controller
+
+**MoveIt Twist Controller** provides direct 6D end-effector motion via geometry_msgs/TwistStamped commands. 
+It leverages the MoveIt inverse kinematics interface and requires a [ros_control](https://control.ros.org/rolling/index.html) *joint position interface*. It also supports collision checks, joint velocity limits, and optional compliance through joint current limits.
+
+
+## Features
+
+- **Direct End-Effector Control**  
+  Send twist commands (`TwistStamped`) to move the end-effector in 6D space.
+
+- **Gripper Control**  
+  Send velocity commands (`Float64`) to open/close the gripper.
+
+- **Collision Avoidance**  
+  Proposed goal poses are checked for collisions via MoveIt before execution.
+
+- **Joint Velocity Limits**  
+  Checks if the requested motion exceeds joint velocity limits (extracted from the moveit::RobotModel).
+
+- **Continuous Joints**  
+  If the inverse kinematics solver proposes an angle jump of `n * 2π` for a continuous joint, the jump is ignored.
+
+- **Compliance (Optional)**  
+  Enables current-limiting on arm joints (using a dynamically reconfigurable interface) to achieve compliance.
+
+
+## ROS Interfaces
+
+### Subscribed Topics
+
+1. **`moveit_twist_controller/eef_cmd`** (`geometry_msgs/TwistStamped`)
+    - Receives direct velocity commands for the end-effector in 6D space (linear and angular velocities).
+
+2. **`moveit_twist_controller/gripper_cmd`** (`std_msgs/Float64`)
+    - Receives velocity commands for the gripper.
+
+### Published Topics
+
+1. **`moveit_twist_controller/goal_pose`** (`geometry_msgs/PoseStamped`)
+    - Publishes the current goal pose of the end-effector after IK calculation and collision checks.
+
+2. **`moveit_twist_controller/enabled`** (`std_msgs/Bool`)
+    - Indicates whether the controller is currently enabled.
+
+3. **`moveit_twist_controller/robot_state`** (`moveit_msgs/RobotState`)
+    - Publishes the goal robot state (with collision checking) for visualization or debugging.
+
+### Services
+
+1. **`moveit_twist_controller/reset_pose`** (`std_srvs/Empty`)
+    - Resets the internal goal pose to the current physical pose of the robot.
+
+2. **`moveit_twist_controller/hold_pose`** (`std_srvs/Bool`)
+    - When called with `true`, holds the robot end-effector’s world pose while, for instance, moving the robot base.
+    - When called with `false`, normal twist-based motions resume.
+
+3. **`moveit_twist_controller/enable_current_limits`** (`std_srvs/Bool`)
+    - Enables/disables the per-joint current limit interface to achieve compliance.
+    - Requires `request_current_interface` to be enabled in the parameters.
+
+
+## Parameters
+
+All parameters are typically defined in a YAML file under the namespace `moveit_twist_controller`. Below are the commonly used ones:
+
+| Parameter Name                   | Default Value                               | Description                                                                                                |
+|----------------------------------|---------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| **`free_angle`**                 | `""`                                        | Axis with a “free” rotation (e.g., for IK in cases of infinite solutions). Acceptable values: `[ "", "x", "y", "z"]`. |
+| **`gripper_joint_name`**         | `"gripper_servo_joint"`                     | Name of the gripper joint in the URDF.                                                                     |
+| **`group_name`**                 | `"arm_group"`                               | MoveIt group to be controlled (the arm’s MoveIt planning group).                                           |
+| **`request_current_interface`**  | `true`                                      | If `true`, the controller will request and use current-limiting interfaces.                                |
+| **`current_limits`**             | `[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]`       | Per-joint current limits in Amps, used if the current-limiting interface is enabled.                        |
+| **`kinematics_solver`**          | `kdl_kinematics_plugin/KDLKinematicsPlugin` | Kinematics solver plugin to use (as an example).                                                        |
+| **`kinematics_solver_timeout`**  | `0.05`                                      | Timeout for the IK solver (in seconds).                                                                    |
+| **`kinematics_solver_attempts`** |  `3`                                        | Number of attempts allowed for the IK solver.                                                              |

--- a/include/moveit_twist_controller/twist_controller.hpp
+++ b/include/moveit_twist_controller/twist_controller.hpp
@@ -69,7 +69,8 @@ private:
   void setupInterfaces();
   static double computeJointAngleDiff( double angle_1, double angle_2 );
   bool setCommand( double value, const std::string &joint_name, const std::string &interface_name );
-  bool getState( double &value, const std::string &joint_name, const std::string &interface_name );
+  bool getState( double &value, const std::string &joint_name,
+                 const std::string &interface_name ) const;
   void updateDynamicParameters();
   /// Transforms pose to desired frame
   /// Pose has to be relative to base frame
@@ -118,6 +119,8 @@ private:
 
   moveit_twist_controller::Params params_;
   std::shared_ptr<moveit_twist_controller::ParamListener> param_listener_;
+  mutable std::map<std::string, size_t> joint_state_interface_mapping_;
+  mutable std::map<std::string, size_t> joint_command_interface_mapping_;
 
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_cmd_sub_;
   rclcpp::Subscription<std_msgs::msg::Float64>::SharedPtr gripper_cmd_sub_;

--- a/include/moveit_twist_controller/twist_controller.hpp
+++ b/include/moveit_twist_controller/twist_controller.hpp
@@ -86,9 +86,7 @@ private:
   bool reset_tool_center_ = false;
   bool move_tool_center_ = false;
 
-  double max_speed_gripper_ = 0.0;
   int free_angle_ = -1;
-  std::string gripper_cmd_mode_;
 
   Eigen::Affine3d tool_center_offset_;
   Eigen::Affine3d tool_goal_pose_;
@@ -101,8 +99,8 @@ private:
   Twist twist_;
   double gripper_pos_ = 0.0;
   double gripper_speed_ = 0.0;
-  double gripper_cmd_speed_;
-  double gripper_cmd_pos_;
+  double gripper_cmd_speed_ = 0.0;
+  double gripper_cmd_pos_ = 0.0;
   std::vector<double> joint_velocity_limits_;
 
   std::vector<std::string> joint_names_;
@@ -116,18 +114,14 @@ private:
 
   double gripper_upper_limit_ = 0.0;
   double gripper_lower_limit_ = 0.0;
-  std::string gripper_joint_name_;
-  double gripper_max_velocity_limit_;
-
-  int64_t velocity_limit_satisfaction_max_iterations_;
-  double velocity_limit_satisfaction_multiplicator_;
+  double gripper_max_velocity_limit_ = 0.0;
 
   InverseKinematics ik_;
   bool hold_pose_ = false;
   geometry_msgs::msg::PoseStamped hold_goal_pose_;
 
-  moveit_twist_controller::Params params_;
-  std::shared_ptr<moveit_twist_controller::ParamListener> param_listener_;
+  Params params_;
+  std::shared_ptr<ParamListener> param_listener_;
   mutable std::map<std::string, size_t> joint_state_interface_mapping_;
   mutable std::map<std::string, size_t> joint_command_interface_mapping_;
 

--- a/include/moveit_twist_controller/twist_controller.hpp
+++ b/include/moveit_twist_controller/twist_controller.hpp
@@ -111,8 +111,6 @@ private:
   double gripper_upper_limit_ = 0.0;
   double gripper_lower_limit_ = 0.0;
 
-  bool reject_if_velocity_limits_violated_ = true;
-
   InverseKinematics ik_;
   bool hold_pose_ = false;
   geometry_msgs::msg::PoseStamped hold_goal_pose_;

--- a/src/inverse_kinematics.cpp
+++ b/src/inverse_kinematics.cpp
@@ -32,10 +32,10 @@ bool InverseKinematics::init( rclcpp_lifecycle::LifecycleNode::SharedPtr lifecyc
   opt.srdf_string = robot_description_semantic;
   opt.robot_description = "robot_description";
 
-  robot_model_loader_.reset( new robot_model_loader::RobotModelLoader( node_, opt ) );
+  robot_model_loader_ = std::make_shared<robot_model_loader::RobotModelLoader>( node_, opt );
   robot_model_ = robot_model_loader_->getModel();
   planning_scene_ = std::make_shared<planning_scene::PlanningScene>( robot_model_ );
-  robot_state_.reset( new moveit::core::RobotState( robot_model_ ) );
+  robot_state_ = std::make_shared<moveit::core::RobotState>( robot_model_ );
   robot_state_->setToDefaultValues();
 
   // load joint model group
@@ -48,7 +48,7 @@ bool InverseKinematics::init( rclcpp_lifecycle::LifecycleNode::SharedPtr lifecyc
   arm_joint_names_ = joint_model_group_->getActiveJointModelNames();
   joint_names_ = robot_model_->getActiveJointModelNames();
   // remove world_virtual_joint
-  if ( joint_names_.size() > 0 && joint_names_[0] == "world_virtual_joint" )
+  if ( !joint_names_.empty() && joint_names_[0] == "world_virtual_joint" )
     joint_names_.erase( joint_names_.begin() );
 
   // Retrieve solver

--- a/src/inverse_kinematics.cpp
+++ b/src/inverse_kinematics.cpp
@@ -80,6 +80,7 @@ bool InverseKinematics::init( rclcpp_lifecycle::LifecycleNode::SharedPtr lifecyc
 bool InverseKinematics::getJointLimits( const std::string &joint_name, double &lower, double &upper,
                                         double &velocity ) const
 {
+  RCLCPP_INFO( node_->get_logger(), "Loading joint limits for %s", joint_name.c_str() );
   if ( robot_model_ ) {
     if ( const auto joint_model = robot_model_->getJointModel( joint_name ) ) {
       const auto bounds = joint_model->getVariableBounds( joint_model->getVariableNames()[0] );

--- a/src/twist_controller.cpp
+++ b/src/twist_controller.cpp
@@ -359,7 +359,7 @@ void MoveitTwistController::updateArm( const rclcpp::Time & /*time*/, const rclc
     }
   }
 
-  if ( reject_if_velocity_limits_violated_ && max_velocity_factor > 1.0 ) {
+  if ( params_.reject_if_velocity_limits_violated && max_velocity_factor > 1.0 ) {
     RCLCPP_WARN( get_node()->get_logger(), "Max velocity factor: %f. Rejected goal state.",
                  max_velocity_factor );
     reset_pose_ = true;

--- a/src/twist_controller.cpp
+++ b/src/twist_controller.cpp
@@ -441,9 +441,9 @@ void MoveitTwistController::updateArm( const rclcpp::Time & /*time*/, const rclc
     }
   } else {
     // IK failed
-    ee_goal_pose_ = old_goal;
+    ee_goal_pose_ = ik_.getEndEffectorPose( previous_goal_state_ );
     goal_state_ = previous_goal_state_;
-    RCLCPP_WARN( get_node()->get_logger(), "IK failed." );
+    RCLCPP_DEBUG( get_node()->get_logger(), "IK failed." );
   }
 
   bool success = true;

--- a/src/twist_controller.cpp
+++ b/src/twist_controller.cpp
@@ -122,7 +122,7 @@ MoveitTwistController::on_configure( const rclcpp_lifecycle::State & /*previous_
 
     // Current limit setup
     if ( params_.request_current_interface ) {
-      if ( params_.current_limits.size() != arm_joint_names_.size() ) {
+      if ( params_.current_limits.arm_joints_map.size() != arm_joint_names_.size() ) {
         RCLCPP_ERROR( get_node()->get_logger(),
                       "Current limits size does not match arm joint names size" );
         return controller_interface::CallbackReturn::ERROR;
@@ -378,7 +378,9 @@ void MoveitTwistController::updateArm( const rclcpp::Time & /*time*/, const rclc
     success &= setCommand( goal_state_[i], arm_joint_names_[i], "position" );
     // if current interfaces requested, write current limit, write 0 if current limits not enabled
     if ( params_.request_current_interface ) {
-      const double limit = set_current_limits_ ? params_.current_limits[i] : 0;
+      const double limit = set_current_limits_
+                               ? params_.current_limits.arm_joints_map[arm_joint_names_[i]].limit
+                               : 0.0;
       success &= setCommand( limit, arm_joint_names_[i], "current" );
     }
   }
@@ -574,7 +576,7 @@ void MoveitTwistController::updateDynamicParameters()
 {
   const auto params = param_listener_->get_params();
   // update current limits
-  if ( params.current_limits.size() != arm_joint_names_.size() ) {
+  if ( params.current_limits.arm_joints_map.size() != arm_joint_names_.size() ) {
     RCLCPP_ERROR( get_node()->get_logger(),
                   "Current limits size does not match arm joint names size" );
     return;

--- a/src/twist_controller.cpp
+++ b/src/twist_controller.cpp
@@ -80,12 +80,9 @@ MoveitTwistController::on_configure( const rclcpp_lifecycle::State & /*previous_
     else if ( params_.free_angle == "z" )
       free_angle_ = 2;
 
-    reject_if_velocity_limits_violated_ = params_.reject_if_velocity_limits_violated;
-
     // create a node to initialize the IK solver
     moveit_init_node_ = std::make_shared<rclcpp::Node>(
         get_node()->get_name() + std::string( "_moveit_init" ), get_node()->get_namespace() );
-
 
     if ( !ik_.init( get_node(), moveit_init_node_, params_.group_name,
                     params_.robot_descriptions_loading_timeout ) )

--- a/src/twist_controller.cpp
+++ b/src/twist_controller.cpp
@@ -378,9 +378,10 @@ void MoveitTwistController::updateArm( const rclcpp::Time & /*time*/, const rclc
     success &= setCommand( goal_state_[i], arm_joint_names_[i], "position" );
     // if current interfaces requested, write current limit, write 0 if current limits not enabled
     if ( params_.request_current_interface ) {
-      const double limit = set_current_limits_
-                               ? params_.current_limits.arm_joints_map[arm_joint_names_[i]].limit
-                               : 0.0;
+      const double limit =
+          set_current_limits_
+              ? params_.current_limits.arm_joints_map[arm_joint_names_[i]].compliant_limit
+              : params_.current_limits.arm_joints_map[arm_joint_names_[i]].stiff_limit;
       success &= setCommand( limit, arm_joint_names_[i], "current" );
     }
   }

--- a/src/twist_controller.yaml
+++ b/src/twist_controller.yaml
@@ -4,7 +4,7 @@ moveit_twist_controller:
       type: string,
       default_value: "",
       description: "Axis where the actual rotation is free. -1 means no free angle.",
-      read_only: false,
+      read_only: true,
       validation: {
         one_of<>: [ [ "","x","y","z" ] ]
       }
@@ -15,7 +15,7 @@ moveit_twist_controller:
       type: string,
       default_value: "gripper_servo_joint",
       description: "Name of the gripper joint in the urdf",
-      read_only: false,
+      read_only: true,
       validation: {
         not_empty<>: [ ]
       }
@@ -26,10 +26,26 @@ moveit_twist_controller:
       type: string,
       default_value: "arm_group",
       description: "Name of the group in the moveit configuration.",
-      read_only: false,
+      read_only: true,
       validation: {
         not_empty<>: [ ]
       }
+    }
+
+  request_current_interface:
+    {
+      type: bool,
+      default_value: false,
+      description: "Request Current Interface per arm joint and provide service for current limit activation.",
+      read_only: true
+    }
+
+  current_limits:
+    {
+      type: double_array,
+      default_value: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      description: "Current limits for each joint in the group in Ampere.",
+      read_only: false
     }
 
   reject_if_velocity_limits_violated:

--- a/src/twist_controller.yaml
+++ b/src/twist_controller.yaml
@@ -48,7 +48,6 @@ moveit_twist_controller:
         description: "Default current limit for each joint in the group in Ampere. Will be set if current interface requested but compliant mode is off."
         read_only: true
 
-
   velocity_limits:
       type: double_array
       default_value: []

--- a/src/twist_controller.yaml
+++ b/src/twist_controller.yaml
@@ -1,69 +1,59 @@
 moveit_twist_controller:
   free_angle:
-    {
-      type: string,
-      default_value: "",
-      description: "Axis where the actual rotation is free. -1 means no free angle.",
-      read_only: true,
-      validation: {
-        one_of<>: [ [ "","x","y","z" ] ]
-      }
-    }
+    type: string
+    default_value: ""
+    description: "Axis where the actual rotation is free. -1 means no free angle."
+    read_only: true
+    validation:
+      one_of<>: [["","x","y","z"]]
 
   gripper_joint_name:
-    {
-      type: string,
-      default_value: "gripper_servo_joint",
-      description: "Name of the gripper joint in the urdf",
-      read_only: true,
-      validation: {
-        not_empty<>: [ ]
-      }
-    }
+    type: string
+    default_value: "gripper_servo_joint"
+    description: "Name of the gripper joint in the urdf"
+    read_only: true
+    validation:
+      not_empty<>: []
 
   group_name:
-    {
-      type: string,
-      default_value: "arm_group",
-      description: "Name of the group in the moveit configuration.",
-      read_only: true,
-      validation: {
-        not_empty<>: [ ]
-      }
-    }
+    type: string
+    default_value: "arm_group"
+    description: "Name of the group in the moveit configuration."
+    read_only: true
+    validation:
+      not_empty<>: [ ]
 
   request_current_interface:
-    {
-      type: bool,
-      default_value: false,
-      description: "Request Current Interface per arm joint and provide service for current limit activation.",
-      read_only: true
-    }
+    type: bool
+    default_value: false
+    description: "Request Current Interface per arm joint and provide service for current limit activation."
+    read_only: true
+
+
+  arm_joints:
+    type: string_array
+    default_value: ["arm_joint_1", "arm_joint_2", "arm_joint_3", "arm_joint_4", "arm_joint_5", "arm_joint_6"]
+    description: "List of joint names in the group."
+    read_only: true
+
 
   current_limits:
-    {
-      type: double_array,
-      default_value: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-      description: "Current limits for each joint in the group in Ampere.",
-      read_only: false
-    }
+    __map_arm_joints:
+      limit:
+        type: double
+        description: "Current limits for each joint in the group in Ampere. 'request_current_interface' must be true."
 
   reject_if_velocity_limits_violated:
-    {
-      type: bool,
-      default_value: true,
-      description: "Reject commands that violate the velocity limits.",
+      type: bool
+      default_value: true
+      description: "Reject commands that violate the velocity limits."
       read_only: false
-    }
 
   robot_descriptions_loading_timeout:
-    {
-      type: double,
-      default_value: 5.0,
-      description: "Timeout for loading the robot description and robot_description_semantic in seconds.",
-      read_only: false,
-      validation: {
+      type: double
+      default_value: 5.0
+      description: "Timeout for loading the robot description and robot_description_semantic in seconds."
+      read_only: false
+      validation:
         gt<>: 0.0
-      }
-    }
 

--- a/src/twist_controller.yaml
+++ b/src/twist_controller.yaml
@@ -48,21 +48,14 @@ moveit_twist_controller:
         description: "Default current limit for each joint in the group in Ampere. Will be set if current interface requested but compliant mode is off."
         read_only: true
 
-  reject_if_velocity_limits_violated:
-      type: bool
-      default_value: true
-      description: "Reject commands that violate the velocity limits."
-      read_only: false
+
   velocity_limits:
-    {
-      type: double_array,
-      default_value: [],
-      description: "Velocity limits in rad/s for the joints in the group. If not set, the default velocity limits from the srdf are used.",
-      read_only: true,
-        validation: {
-          lower_element_bounds<>: [0.0],
-        }
-    }
+      type: double_array
+      default_value: []
+      description: "Velocity limits in rad/s for the joints in the group. If not set, the default velocity limits from the srdf are used."
+      read_only: true
+      validation:
+        lower_element_bounds<>: [0.0]
 
   robot_descriptions_loading_timeout:
       type: double
@@ -73,37 +66,28 @@ moveit_twist_controller:
         gt<>: 0.0
 
   velocity_limit_satisfaction_max_iterations:
-    {
-      type: int,
-      default_value: 3,
-      description: "Maximum number of iterations of the velocity limit satisfaction algorithm.",
-      read_only: false,
-      validation: {
+      type: int
+      default_value: 3
+      description: "Maximum number of iterations of the velocity limit satisfaction algorithm."
+      read_only: false
+      validation:
         gt<>: 0
-      }
-    }
 
   velocity_limit_satisfaction_multiplicator:
-    {
-      type: double,
-      default_value: 0.5,
-      description: "Multiplicator for the velocity limit satisfaction algorithm. (0,1)",
-      read_only: false,
-      validation: {
+      type: double
+      default_value: 0.5
+      description: "Multiplicator for the velocity limit satisfaction algorithm. (0,1)"
+      read_only: false
+      validation:
         bounds<>: [ 0.0, 1.0 ]
-      }
-    }
 
   gripper_cmd_mode:
-    {
-      type: string,
-      default_value: "velocity",
-      description: "Mode of the gripper. 'velocity' or 'position'.",
-      read_only: false,
-      validation: {
+      type: string
+      default_value: "velocity"
+      description: "Mode of the gripper. 'velocity' or 'position'."
+      read_only: false
+      validation:
         one_of<>: [ [ "velocity", "position" ] ]
-      }
-    }
 
 
 

--- a/src/twist_controller.yaml
+++ b/src/twist_controller.yaml
@@ -39,9 +39,14 @@ moveit_twist_controller:
 
   current_limits:
     __map_arm_joints:
-      limit:
+      compliant_limit:
         type: double
         description: "Current limits for each joint in the group in Ampere. 'request_current_interface' must be true."
+        read_only: true
+      stiff_limit:
+        type: double
+        description: "Default current limit for each joint in the group in Ampere. Will be set if current interface requested but compliant mode is off."
+        read_only: true
 
   reject_if_velocity_limits_violated:
       type: bool

--- a/src/twist_controller.yaml
+++ b/src/twist_controller.yaml
@@ -36,7 +36,6 @@ moveit_twist_controller:
     description: "List of joint names in the group."
     read_only: true
 
-
   current_limits:
     __map_arm_joints:
       compliant_limit:


### PR DESCRIPTION
Implemented current limits for compliant arm behavior.

Request current command interface by setting read-only parameter `request_current_interface`.

Enable/disable the current limits via a service call on `moveit_twist_controller/enable_current_limits`  (current limits are off at start-up).

Set reconfigurable parameters for current limits (only updated when enabling/disabling current limits).
Parameter Update fails if the number of current limits does not equal the number of joints in the selected move group!