### PR TITLE
Feature/arbitrary eef velocity frame

### DIFF
--- a/include/moveit_twist_controller/inverse_kinematics.hpp
+++ b/include/moveit_twist_controller/inverse_kinematics.hpp
@@ -33,6 +33,7 @@ public:
   std::vector<std::string> getGroupJointNames();
   std::vector<std::string> getAllJointNames() const;
   std::string getBaseFrame() const;
+  std::string getTipFrame() const;
   bool getJointLimits( const std::string &joint_name, double &lower, double &upper ) const;
   std::vector<double> getJointVelocityLimits() const;
 

--- a/src/inverse_kinematics.cpp
+++ b/src/inverse_kinematics.cpp
@@ -175,6 +175,11 @@ std::string InverseKinematics::getBaseFrame() const
   return joint_model_group_->getSolverInstance()->getBaseFrame();
 }
 
+std::string InverseKinematics::getTipFrame() const
+{
+  return joint_model_group_->getSolverInstance()->getTipFrame();
+}
+
 std::string InverseKinematics::moveitErrCodeToString( const int32_t code )
 {
   switch ( code ) {


### PR DESCRIPTION
Allows sending Twist messages in arbitrary frames. 
This improves control flexibility. For example, using the camera or end-effector frame makes remote control more intuitive. When operating the robot in person, using the base_link frame might feel more natural, as it matches the robot's physical orientation.