### PR TITLE
make sure joint velocity limits are satisfied

### DIFF
--- a/include/moveit_twist_controller/twist_controller.hpp
+++ b/include/moveit_twist_controller/twist_controller.hpp
@@ -72,6 +72,9 @@ private:
   /// Pose has to be relative to base frame
   geometry_msgs::msg::PoseStamped getPoseInFrame( const Eigen::Affine3d &pose,
                                                   const std::string &frame );
+  bool calculateInverseKinematicsConsideringVelocityLimits( Eigen::Affine3d &new_eef_pose,
+                                                            const Eigen::Affine3d &old_eef_pose,
+                                                            const rclcpp::Duration &period );
 
   bool initialized_ = false;
   bool enabled_;

--- a/include/moveit_twist_controller/twist_controller.hpp
+++ b/include/moveit_twist_controller/twist_controller.hpp
@@ -110,6 +110,9 @@ private:
   double gripper_upper_limit_;
   double gripper_lower_limit_;
 
+  int64_t velocity_limit_satisfaction_max_iterations_;
+  double velocity_limit_satisfaction_multiplicator_;
+
   bool reject_if_velocity_limits_violated_ = true;
 
   InverseKinematics ik_;

--- a/src/inverse_kinematics.cpp
+++ b/src/inverse_kinematics.cpp
@@ -12,9 +12,9 @@ bool InverseKinematics::init( rclcpp_lifecycle::LifecycleNode::SharedPtr lifecyc
 {
   node_ = node;                     // NOT SPINNING -> NO CALLBACKS BUT PARAMETERS SHOULD WORK
   lifecycle_node_ = lifecycle_node; // SPINNING -> CALLBACKS WORK
-  RCLCPP_INFO( node_->get_logger(), "Initializing inverse kinematics controller in namespace '%s'.",
-               node_->get_namespace() );
-  RCLCPP_INFO( node_->get_logger(), "Moveit Group name: %s", group_name.c_str() );
+  RCLCPP_DEBUG( node_->get_logger(), "Initializing inverse kinematics controller in namespace '%s'.",
+                node_->get_namespace() );
+  RCLCPP_DEBUG( node_->get_logger(), "Moveit Group name: %s", group_name.c_str() );
   auto robot_description =
       getParameterFromTopic( "robot_description", robot_descriptions_loading_timeout );
   auto robot_description_semantic =
@@ -59,7 +59,7 @@ bool InverseKinematics::init( rclcpp_lifecycle::LifecycleNode::SharedPtr lifecyc
                   joint_model_group_->getName().c_str() );
     return false;
   }
-  RCLCPP_INFO( node_->get_logger(), "IK solver: %s", typeid( *solver ).name() );
+  RCLCPP_DEBUG( node_->get_logger(), "IK solver: %s", typeid( *solver ).name() );
   tip_frame_ = solver->getTipFrame();
 
   // Debug output
@@ -72,7 +72,7 @@ bool InverseKinematics::init( rclcpp_lifecycle::LifecycleNode::SharedPtr lifecyc
   for ( unsigned int i = 0; i < arm_joint_names_.size(); i++ ) {
     debug << i << ": " << arm_joint_names_[i] << std::endl;
   }
-  RCLCPP_INFO( node_->get_logger(), debug.str().c_str() );
+  RCLCPP_DEBUG( node_->get_logger(), debug.str().c_str() );
 
   return true;
 }
@@ -107,12 +107,12 @@ bool InverseKinematics::calcInvKin( const Eigen::Affine3d &pose, const std::vect
   solution.resize( arm_joint_names_.size() );
   if ( !joint_model_group_->getSolverInstance()->searchPositionIK( pose_msg, seed, 0.01, solution,
                                                                    error_code ) ) {
-    RCLCPP_WARN_STREAM( node_->get_logger(),
-                        "Computing IK from "
-                            << joint_model_group_->getSolverInstance()->getBaseFrame() << " to "
-                            << joint_model_group_->getSolverInstance()->getTipFrame()
-                            << " failed. Error code: " << error_code.val << " ("
-                            << moveitErrCodeToString( error_code.val ) << ")" );
+    RCLCPP_DEBUG_STREAM( node_->get_logger(),
+                         "Computing IK from "
+                             << joint_model_group_->getSolverInstance()->getBaseFrame() << " to "
+                             << joint_model_group_->getSolverInstance()->getTipFrame()
+                             << " failed. Error code: " << error_code.val << " ("
+                             << moveitErrCodeToString( error_code.val ) << ")" );
     return false;
   }
 

--- a/src/twist_controller.cpp
+++ b/src/twist_controller.cpp
@@ -78,8 +78,6 @@ MoveitTwistController::on_configure( const rclcpp_lifecycle::State & /*previous_
     else if ( params.free_angle == "z" )
       free_angle_ = 2;
 
-    reject_if_velocity_limits_violated_ = params.reject_if_velocity_limits_violated;
-
     // create a node to initialize the IK solver
     moveit_init_node_ = std::make_shared<rclcpp::Node>(
         get_node()->get_name() + std::string( "_moveit_init" ), get_node()->get_namespace() );
@@ -103,7 +101,15 @@ MoveitTwistController::on_configure( const rclcpp_lifecycle::State & /*previous_
         return controller_interface::CallbackReturn::ERROR;
       }
     }
-    joint_velocity_limits_ = ik_.getJointVelocityLimits();
+    joint_velocity_limits_ = params.velocity_limits;
+    if ( const auto srdf_limits = ik_.getJointVelocityLimits();
+         srdf_limits.size() != joint_velocity_limits_.size() ) {
+      RCLCPP_WARN( get_node()->get_logger(),
+                   "The given velocity limits (%lu) do not match the "
+                   "velocity limits from the SRDF (%lu). Using the SRDF limits.",
+                   joint_velocity_limits_.size(), srdf_limits.size() );
+      joint_velocity_limits_ = srdf_limits;
+    }
     goal_state_.resize( arm_joint_names_.size() );
     current_joint_angles_.resize( joint_names_.size() );
     current_arm_joint_angles.resize( arm_joint_names_.size() );
@@ -237,7 +243,6 @@ MoveitTwistController::on_activate( const rclcpp_lifecycle::State & /*previous_s
     gripper_pos_ = 0.0;
   }
   gripper_speed_ = 0.0;
-
   initialized_ = true;
   enabled_ = true;
 
@@ -324,16 +329,65 @@ double MoveitTwistController::computeJointAngleDiff( const double angle_1, const
   return diff;
 }
 
+bool MoveitTwistController::calculateInverseKinematicsConsideringVelocityLimits(
+    Eigen::Affine3d &new_eef_pose, const Eigen::Affine3d &old_eef_pose,
+    const rclcpp::Duration &period )
+{
+  double factor = 1.0;
+  int count = 0;
+  constexpr int max_iterations = 3;
+  constexpr double multiplicator = 0.5;
+
+  while ( count < max_iterations ) {
+    // Try IK
+    if ( ik_.calcInvKin( new_eef_pose, previous_goal_state_, goal_state_ ) ) {
+      double max_velocity_factor = 0;
+      for ( size_t i = 0; i < goal_state_.size(); ++i ) {
+        const double angle_diff =
+            std::abs( computeJointAngleDiff( previous_goal_state_[i], goal_state_[i] ) );
+        max_velocity_factor = std::max(
+            max_velocity_factor, angle_diff / ( joint_velocity_limits_[i] * period.seconds() ) );
+        /*if ( angle_diff / ( joint_velocity_limits_[i] * period.seconds() ) > 1.0 ) {
+          RCLCPP_WARN(
+              get_node()->get_logger(), "Joint %s: Max change in joint angles is > 1.0 Old State: %f, New State: %f, angle diff %f",
+              arm_joint_names_[i].c_str(), previous_goal_state_[i], goal_state_[i], angle_diff );
+        }*/
+      }
+      if ( max_velocity_factor <= 1.0 ) {
+        return true;
+      }
+    }
+
+    factor *= multiplicator;
+    count++;
+
+    // Interpolate translation
+    const Eigen::Vector3d interp_translation =
+        old_eef_pose.translation() +
+        factor * ( new_eef_pose.translation() - old_eef_pose.translation() );
+
+    // Interpolate rotation using slerp
+    Eigen::Quaterniond old_q( old_eef_pose.rotation() );
+    Eigen::Quaterniond new_q( new_eef_pose.rotation() );
+    Eigen::Quaterniond interp_q = old_q.slerp( factor, new_q );
+
+    // Create interpolated pose
+    new_eef_pose.linear() = interp_q.toRotationMatrix();
+    new_eef_pose.translation() = interp_translation;
+  }
+  return false;
+}
+
 void MoveitTwistController::updateArm( const rclcpp::Time & /*time*/, const rclcpp::Duration &period )
 {
-  Eigen::Affine3d old_goal = ee_goal_pose_;
+  const Eigen::Affine3d old_goal = ee_goal_pose_;
   previous_goal_state_ = goal_state_;
 
   // Compute new goal pose
   computeNewGoalPose( period );
 
   // Compute IK
-  if ( ik_.calcInvKin( ee_goal_pose_, previous_goal_state_, goal_state_ ) ) {
+  if ( calculateInverseKinematicsConsideringVelocityLimits( ee_goal_pose_, old_goal, period ) ) {
     contact_map_.clear();
     sensor_msgs::msg::JointState joint_state;
     joint_state.name = joint_names_;
@@ -346,35 +400,9 @@ void MoveitTwistController::updateArm( const rclcpp::Time & /*time*/, const rclc
     }
   } else {
     // IK failed
-    ee_goal_pose_ = old_goal;
+    ee_goal_pose_ = ik_.getEndEffectorPose( previous_goal_state_ );
     goal_state_ = previous_goal_state_;
     RCLCPP_WARN( get_node()->get_logger(), "IK failed." );
-  }
-  // Make sure that the change in joint angles is not too large -> velocity limits
-  double max_velocity_factor = 0;
-  for ( size_t i = 0; i < goal_state_.size(); ++i ) {
-    const double angle_diff =
-        std::abs( computeJointAngleDiff( previous_goal_state_[i], goal_state_[i] ) );
-    max_velocity_factor = std::max( max_velocity_factor,
-                                    angle_diff / ( joint_velocity_limits_[i] * period.seconds() ) );
-    if ( angle_diff / ( joint_velocity_limits_[i] * period.seconds() ) > 1.0 ) {
-      RCLCPP_WARN(
-          get_node()->get_logger(), "Joint %s: Max change in joint angles is > 1.0 Old State: %f, New State: %f, angle diff %f",
-          arm_joint_names_[i].c_str(), previous_goal_state_[i], goal_state_[i], angle_diff );
-    }
-  }
-
-  if ( reject_if_velocity_limits_violated_ && max_velocity_factor > 1.0 ) {
-    RCLCPP_WARN( get_node()->get_logger(), "Max velocity factor: %f. Rejected goal state.",
-                 max_velocity_factor );
-    reset_pose_ = true;
-    goal_state_ = previous_goal_state_;
-  } else {
-    // avoid jumps in joint angles especially in the continuous joints!!
-    for ( size_t i = 0; i < goal_state_.size(); ++i ) {
-      goal_state_[i] =
-          previous_goal_state_[i] + computeJointAngleDiff( previous_goal_state_[i], goal_state_[i] );
-    }
   }
 
   bool success = true;

--- a/src/twist_controller.yaml
+++ b/src/twist_controller.yaml
@@ -32,12 +32,15 @@ moveit_twist_controller:
       }
     }
 
-  reject_if_velocity_limits_violated:
+  velocity_limits:
     {
-      type: bool,
-      default_value: true,
-      description: "Reject commands that violate the velocity limits.",
-      read_only: false
+      type: double_array,
+      default_value: [],
+      description: "Velocity limits in rad/s for the joints in the group. If not set, the default velocity limits from the srdf are used.",
+      read_only: true,
+        validation: {
+          lower_element_bounds<>: [0.0],
+        }
     }
 
   robot_descriptions_loading_timeout:

--- a/src/twist_controller.yaml
+++ b/src/twist_controller.yaml
@@ -54,3 +54,24 @@ moveit_twist_controller:
       }
     }
 
+  velocity_limit_satisfaction_max_iterations:
+    {
+      type: int,
+      default_value: 3,
+      description: "Maximum number of iterations of the velocity limit satisfaction algorithm.",
+      read_only: false,
+      validation: {
+        gt<>: 0
+      }
+    }
+
+  velocity_limit_satisfaction_multiplicator:
+    {
+    type: double,
+    default_value: 0.5,
+    description: "Multiplicator for the velocity limit satisfaction algorithm. (0,1)",
+    read_only: false,
+    validation: {
+      bounds<>:[0.0, 1.0]
+      }
+    }


### PR DESCRIPTION
This PR ensures that joint velocity limits are respected during inverse kinematics solving. Limits can be set via the joint_velocities parameter or fall back to SRDF values. If the target pose violates velocity constraints, it is iteratively interpolated toward the previous pose until a valid solution is found or a maximum number of attempts is reached. This helps prevent sudden joint jumps and improves stability without overly restricting motion.