### PR TITLE
Remove gripper control from moveit_twist_controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,10 @@ All parameters are typically defined in a YAML file under the namespace `moveit_
 | **`kinematics_solver_attempts`**                 | `3`                                                                                          | Number of IK attempts before failing.                                                                            |
 | **`solve_type`**                                 | `Distance`                                                                                   | Strategy for choosing an IK solution. Options: `Distance` (closest to seed) or `Speed` (fastest).                |
 
+## Related Controllers
+
+Gripper control and joint/current-limit safety used to live in this package; they now sit in [hector_ros_controllers](../hector_ros_controllers):
+
+- `gripper_position_effort_controller/GripperPositionEffortController` — standalone gripper controller (action + position/velocity topics, optional max-effort limits).
+- `safety_position_controller/SafetyPositionController` — chainable position controller that enforces joint and current limits and runs self-collision avoidance. Use it as the downstream controller by setting this package's `chained_controller` parameter to its name.
+

--- a/README.md
+++ b/README.md
@@ -54,21 +54,25 @@ All parameters are typically defined in a YAML file under the namespace `moveit_
 
 | Parameter Name                                   | Default                                                                                      | Description                                                                                                      |
 | ------------------------------------------------ | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **`group_name`**                                 | `arm_tcp_group`                                                                              | MoveIt planning group to control.                                                                                |
-| **`arm_joints`**                                 | `["arm_joint_1", "arm_joint_2", "arm_joint_3", "arm_joint_4", "arm_joint_5", "arm_joint_6"]` | List of all joints in the move group (same order).                                                               |
+| **`group_name`**                                 | `arm_tcp_group`                                                                              | MoveIt planning group to control. Joint names are taken from this group.                                         |
 | **`robot_descriptions_loading_timeout`**         | `10.0`                                                                                       | Seconds to wait for the robot descriptions (URDF/SRDF) to load.                                                  |
 | **`free_angle`**                                 | `""`                                                                                         | Axis with a “free” rotation (for IK redundancy). Acceptable values: `""`, `"x"`, `"y"`, `"z"`.                   |
 | **`velocity_limits`**                            | `[]`                                                                                         | Maximum joint velocities (rad/s) for each arm joint. If empty the limits from the SRDF will be used.             |
 | **`velocity_limit_satisfaction_max_iterations`** | `3`                                                                                          | Maximum number of recursive scaling iterations to satisfy joint-velocity limits.                                 |
 | **`velocity_limit_satisfaction_multiplicator`**  | `0.33`                                                                                       | Multiplicative factor ($\alpha$) used to scale back target pose when joint-velocity limits are violated.         |
-| **`kinematics_solver`**                          | `trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin`                                          | Plug-in name for the IK solver.                                                                                  |
-| **`kinematics_solver_timeout`**                  | `0.001`                                                                                      | Timeout for each IK request (seconds). Make sure controller does not take too long.                              |
+
+The following parameters are forwarded to the MoveIt group (set on the `robot_description_kinematics.<group_name>` namespace) and can be overridden via the standard MoveIt kinematics YAML:
+
+| Parameter Name                                   | Default                                                                                      | Description                                                                                                      |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **`kinematics_solver`**                          | `pick_ik/PickIkPlugin`                                                                       | Plug-in name for the IK solver.                                                                                  |
+| **`kinematics_solver_timeout`**                  | `0.05`                                                                                       | Timeout for each IK request (seconds). Make sure controller does not take too long.                              |
 | **`kinematics_solver_attempts`**                 | `3`                                                                                          | Number of IK attempts before failing.                                                                            |
-| **`solve_type`**                                 | `Distance`                                                                                   | Strategy for choosing an IK solution. Options: `Distance` (closest to seed) or `Speed` (fastest).                |
+| **`solve_type`**                                 | `Distance`                                                                                   | `trac_ik`-specific: strategy for choosing an IK solution. Options: `Distance` (closest to seed) or `Speed` (fastest). |
 
 ## Related Controllers
 
-Gripper control and joint/current-limit safety used to live in this package; they now sit in [hector_ros_controllers](../hector_ros_controllers):
+Gripper control and joint/current-limit safety used to live in this package; they now sit in [hector_ros_controllers](https://github.com/tu-darmstadt-ros-pkg/hector_ros_controllers):
 
 - `gripper_position_effort_controller/GripperPositionEffortController` — standalone gripper controller (action + position/velocity topics, optional max-effort limits).
 - `safety_position_controller/SafetyPositionController` — chainable position controller that enforces joint and current limits and runs self-collision avoidance. Use it as the downstream controller by setting this package's `chained_controller` parameter to its name.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ It leverages the MoveIt inverse kinematics interface and requires a [ros_control
 - **Direct End-Effector Control**  
   Send twist commands (`TwistStamped`) to move the end-effector in 6D space.
 
-- **Gripper Control**  
-  Send velocity commands (`Float64`) to open/close the gripper.
-
 - **Collision Avoidance**  
   Proposed goal poses are checked for collisions via MoveIt before execution.
 
@@ -30,9 +27,6 @@ It leverages the MoveIt inverse kinematics interface and requires a [ros_control
 
 1. **`moveit_twist_controller/eef_cmd`** (`geometry_msgs/TwistStamped`)
     - Receives direct velocity commands for the end-effector in 6D space (linear and angular velocities).
-
-2. **`moveit_twist_controller/gripper_cmd`** (`std_msgs/Float64`)
-    - Receives velocity commands for the gripper.
 
 ### Published Topics
 
@@ -61,7 +55,6 @@ All parameters are typically defined in a YAML file under the namespace `moveit_
 | Parameter Name                                   | Default                                                                                      | Description                                                                                                      |
 | ------------------------------------------------ | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | **`group_name`**                                 | `arm_tcp_group`                                                                              | MoveIt planning group to control.                                                                                |
-| **`gripper_joint_name`**                         | `gripper_servo_joint`                                                                        | Name of the gripper joint in the URDF.                                                                           |
 | **`arm_joints`**                                 | `["arm_joint_1", "arm_joint_2", "arm_joint_3", "arm_joint_4", "arm_joint_5", "arm_joint_6"]` | List of all joints in the move group (same order).                                                               |
 | **`robot_descriptions_loading_timeout`**         | `10.0`                                                                                       | Seconds to wait for the robot descriptions (URDF/SRDF) to load.                                                  |
 | **`free_angle`**                                 | `""`                                                                                         | Axis with a “free” rotation (for IK redundancy). Acceptable values: `""`, `"x"`, `"y"`, `"z"`.                   |

--- a/config/athena.yaml
+++ b/config/athena.yaml
@@ -4,7 +4,6 @@
 #  ros__parameters:
 #    type: moveit_twist_controller/MoveitTwistController
 #    group_name: arm_tcp_group # arm_with_gripper_cam_group
-#    gripper_joint_name: gripper_servo_joint
 #
 #    # moveit params
 #    kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin

--- a/include/moveit_twist_controller/inverse_kinematics.hpp
+++ b/include/moveit_twist_controller/inverse_kinematics.hpp
@@ -35,8 +35,6 @@ public:
   std::vector<std::string> getAllJointNames() const;
   std::string getBaseFrame() const;
   std::string getTipFrame() const;
-  bool getJointLimits( const std::string &joint_name, double &lower, double &upper,
-                       double &velocity ) const;
   std::vector<double> getJointVelocityLimits() const;
 
 private:

--- a/include/moveit_twist_controller/twist_controller.hpp
+++ b/include/moveit_twist_controller/twist_controller.hpp
@@ -14,7 +14,6 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "realtime_tools/realtime_buffer.hpp"
 #include "realtime_tools/realtime_publisher.hpp"
-#include "std_msgs/msg/float64.hpp"
 #include "std_srvs/srv/empty.hpp"
 #include "std_srvs/srv/set_bool.hpp"
 #include "tf2_ros/buffer.h"
@@ -33,11 +32,6 @@ struct Twist {
 
 struct TwistCommand {
   Twist twist = { Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero() };
-  rclcpp::Time stamp = rclcpp::Time( 0, 0, RCL_CLOCK_UNINITIALIZED );
-};
-
-struct GripperVelCommand {
-  double speed = 0.0;
   rclcpp::Time stamp = rclcpp::Time( 0, 0, RCL_CLOCK_UNINITIALIZED );
 };
 
@@ -63,10 +57,8 @@ public:
 
 private:
   void publishStatus() const;
-  bool loadGripperJointLimits();
   void updateArm( const rclcpp::Time &time, const rclcpp::Duration &period );
   bool computeNewGoalPose( const rclcpp::Duration &period );
-  void updateGripper( const rclcpp::Time &time, const rclcpp::Duration &period );
 
   bool resetPoseCb( const std_srvs::srv::Empty::Request::SharedPtr request,
                     std_srvs::srv::Empty::Response::SharedPtr response );
@@ -107,12 +99,7 @@ private:
   collision_detection::CollisionResult::ContactMap contact_map_;
 
   realtime_tools::RealtimeBuffer<TwistCommand> twist_cmd_buf_;
-  realtime_tools::RealtimeBuffer<GripperVelCommand> gripper_vel_cmd_buf_;
-  std::atomic<double> gripper_cmd_pos_ = 0.0;
   Twist twist_;
-  double gripper_pos_ = 0.0;
-  double gripper_speed_ = 0.0;
-  double gripper_cmd_speed_ = 0.0;
   std::vector<double> joint_velocity_limits_;
   std::vector<double> smoothed_joint_velocities_;
 
@@ -122,11 +109,6 @@ private:
   std::vector<double> current_joint_angles_;
   std::vector<double> current_arm_joint_angles;
   std::vector<int> arm_joint_indices_; // indices of arm joints in joint_names_
-  int gripper_index_ = 0;              // index of gripper in joint_names_
-
-  double gripper_upper_limit_ = 0.0;
-  double gripper_lower_limit_ = 0.0;
-  double gripper_max_velocity_limit_ = 0.0;
 
   InverseKinematics ik_;
   std::atomic<bool> hold_pose_ = false;
@@ -138,8 +120,6 @@ private:
   mutable std::map<std::string, size_t> joint_command_interface_mapping_;
 
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_cmd_sub_;
-  rclcpp::Subscription<std_msgs::msg::Float64>::SharedPtr gripper_pos_cmd_sub_;
-  rclcpp::Subscription<std_msgs::msg::Float64>::SharedPtr gripper_vel_cmd_sub_;
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr reset_pose_server_;
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr reset_tool_center_server_;
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr hold_pose_server_;
@@ -154,7 +134,6 @@ private:
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
   rclcpp::Node::SharedPtr moveit_init_node_;
-  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
 };
 
 } // namespace moveit_twist_controller

--- a/src/inverse_kinematics.cpp
+++ b/src/inverse_kinematics.cpp
@@ -90,22 +90,6 @@ bool InverseKinematics::init( rclcpp_lifecycle::LifecycleNode::SharedPtr lifecyc
   return true;
 }
 
-bool InverseKinematics::getJointLimits( const std::string &joint_name, double &lower, double &upper,
-                                        double &velocity ) const
-{
-  RCLCPP_INFO( node_->get_logger(), "Loading joint limits for %s", joint_name.c_str() );
-  if ( robot_model_ ) {
-    if ( const auto joint_model = robot_model_->getJointModel( joint_name ) ) {
-      const auto bounds = joint_model->getVariableBounds( joint_model->getVariableNames()[0] );
-      lower = bounds.min_position_;
-      upper = bounds.max_position_;
-      velocity = bounds.max_velocity_;
-      return true;
-    }
-  }
-  return false;
-}
-
 bool InverseKinematics::calcInvKin( const Eigen::Affine3d &pose, const std::vector<double> &seed,
                                     std::vector<double> &solution )
 {

--- a/src/twist_controller.cpp
+++ b/src/twist_controller.cpp
@@ -26,9 +26,6 @@ controller_interface::InterfaceConfiguration MoveitTwistController::command_inte
     config.names.push_back( prefix + joint_name + "/position" );
     joint_command_interface_mapping_[joint_name + "/position"] = index++;
   }
-  // The gripper joint (no chained controller prefix)
-  config.names.push_back( params_.gripper_joint_name + std::string( "/position" ) );
-  joint_command_interface_mapping_[params_.gripper_joint_name + "/position"] = index++;
   return config;
 }
 
@@ -56,30 +53,6 @@ controller_interface::CallbackReturn MoveitTwistController::on_init()
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>( *tf_buffer_ );
 
     param_listener_ = std::make_shared<moveit_twist_controller::ParamListener>( get_node() );
-
-    param_callback_handle_ = get_node()->add_on_set_parameters_callback(
-        [this]( const std::vector<rclcpp::Parameter> &params ) {
-          // iterate parameters if it is "gripper_cmd_mode" -> update the mode
-          rcl_interfaces::msg::SetParametersResult result;
-          result.successful = true;
-          for ( const auto &param : params ) {
-            if ( param.get_name() == "gripper_cmd_mode" ) {
-              if ( param.get_type() == rclcpp::ParameterType::PARAMETER_STRING ) {
-                if ( param.as_string() != "velocity" && param.as_string() != "position" ) {
-                  result.successful = false;
-                  result.reason = "gripper_cmd_mode must be either 'velocity' or 'position'";
-                } else {
-                  params_.gripper_cmd_mode = param.as_string();
-                }
-              } else {
-                result.successful = false;
-                result.reason = "gripper_cmd_mode must be a string";
-              }
-              return result;
-            }
-          }
-          return result;
-        } );
   } catch ( const std::exception &e ) {
     RCLCPP_ERROR( get_node()->get_logger(), "Exception during on_init: %s", e.what() );
     return controller_interface::CallbackReturn::ERROR;
@@ -139,11 +112,6 @@ MoveitTwistController::on_configure( const rclcpp_lifecycle::State & /*previous_
     previous_goal_state_.resize( arm_joint_names_.size() );
     smoothed_joint_velocities_.assign( arm_joint_names_.size(), 0.0 );
 
-    RCLCPP_INFO( get_node()->get_logger(), "Gripper joint: %s", params_.gripper_joint_name.c_str() );
-    if ( !loadGripperJointLimits() ) {
-      return controller_interface::CallbackReturn::ERROR;
-    }
-
     // Create publishers and subscriptions.
     goal_pose_pub_ =
         get_node()->create_publisher<geometry_msgs::msg::PoseStamped>( "~/goal_pose", 10 );
@@ -190,20 +158,6 @@ MoveitTwistController::on_configure( const rclcpp_lifecycle::State & /*previous_
           cmd.twist.angular = Eigen::Vector3d( ang_out.x(), ang_out.y(), ang_out.z() );
           cmd.stamp = get_node()->now();
           twist_cmd_buf_.writeFromNonRT( cmd );
-        } );
-
-    // Gripper speed subscription
-    gripper_vel_cmd_sub_ = get_node()->create_subscription<std_msgs::msg::Float64>(
-        "~/gripper_vel_cmd", 10, [this]( const std_msgs::msg::Float64::SharedPtr msg ) {
-          GripperVelCommand cmd;
-          cmd.speed = msg->data;
-          cmd.stamp = get_node()->now();
-          gripper_vel_cmd_buf_.writeFromNonRT( cmd );
-        } );
-
-    gripper_pos_cmd_sub_ = get_node()->create_subscription<std_msgs::msg::Float64>(
-        "~/gripper_pos_cmd", 10, [this]( const std_msgs::msg::Float64::SharedPtr msg ) {
-          gripper_cmd_pos_.store( msg->data, std::memory_order_relaxed );
         } );
 
     // Services
@@ -267,19 +221,11 @@ MoveitTwistController::on_activate( const rclcpp_lifecycle::State & /*previous_s
   TwistCommand zero_twist;
   zero_twist.stamp = rclcpp::Time( 0, 0, clock_type );
   twist_cmd_buf_.writeFromNonRT( zero_twist );
-  GripperVelCommand zero_gripper_vel;
-  zero_gripper_vel.stamp = rclcpp::Time( 0, 0, clock_type );
-  gripper_vel_cmd_buf_.writeFromNonRT( zero_gripper_vel );
-  gripper_cmd_pos_.store( 0.0, std::memory_order_relaxed );
   reset_pose_.store( true );
   reset_tool_center_.store( false );
   move_tool_center_.store( false );
   hold_pose_.store( false );
 
-  if ( !getState( gripper_pos_, params_.gripper_joint_name, "position" ) ) {
-    gripper_pos_ = 0.0;
-  }
-  gripper_cmd_speed_ = 0.0;
   std::fill( smoothed_joint_velocities_.begin(), smoothed_joint_velocities_.end(), 0.0 );
 
   initialized_ = true;
@@ -340,18 +286,9 @@ controller_interface::return_type MoveitTwistController::update( const rclcpp::T
       twist_ = twist_cmd.twist;
     }
   }
-  {
-    const auto &gripper_vel_cmd = *gripper_vel_cmd_buf_.readFromRT();
-    if ( ( time - gripper_vel_cmd.stamp ).seconds() > cmd_timeout ) {
-      gripper_cmd_speed_ = 0.0;
-    } else {
-      gripper_cmd_speed_ = gripper_vel_cmd.speed;
-    }
-  }
 
   // Compute next state
   updateArm( time, period );
-  updateGripper( time, period );
 
   publishCollisionMarkers();
 
@@ -545,41 +482,6 @@ bool MoveitTwistController::getState( double &value, const std::string &joint_na
       state_interfaces_[joint_state_interface_mapping_[joint_name + "/" + interface_name]].get_optional();
   value = state.value();
   return state.has_value();
-}
-
-void MoveitTwistController::updateGripper( const rclcpp::Time & /*time*/,
-                                           const rclcpp::Duration &period )
-{
-  gripper_pos_ += period.seconds() * gripper_speed_;
-  gripper_pos_ = std::min( gripper_upper_limit_, std::max( gripper_lower_limit_, gripper_pos_ ) );
-
-  double applied_gripper_vel = 0.0;
-  if ( params_.gripper_cmd_mode == "velocity" ) {
-    applied_gripper_vel = gripper_cmd_speed_;
-  } else if ( params_.gripper_cmd_mode == "position" ) {
-    // use gripper_pose_cmd but make sure the velocity is not too high
-    const double cmd_pos = gripper_cmd_pos_.load( std::memory_order_relaxed );
-    applied_gripper_vel = std::clamp( ( cmd_pos - gripper_pos_ ) / period.seconds(),
-                                      -gripper_max_velocity_limit_, gripper_max_velocity_limit_ );
-  } else {
-    RCLCPP_ERROR( get_node()->get_logger(), "Invalid gripper mode." );
-    // applied_gripper_vel is zero
-  }
-  gripper_pos_ = std::clamp( applied_gripper_vel * period.seconds() + gripper_pos_,
-                             gripper_lower_limit_, gripper_upper_limit_ );
-  if ( !setCommand( gripper_pos_, params_.gripper_joint_name, "position" ) ) {
-    RCLCPP_WARN( get_node()->get_logger(), "Failed to write gripper command to hardware." );
-  }
-}
-
-bool MoveitTwistController::loadGripperJointLimits()
-{
-  if ( !ik_.getJointLimits( params_.gripper_joint_name, gripper_lower_limit_, gripper_upper_limit_,
-                            gripper_max_velocity_limit_ ) ) {
-    RCLCPP_WARN( get_node()->get_logger(), "Failed to load gripper joint limits." );
-    return false;
-  }
-  return true;
 }
 
 void MoveitTwistController::publishCollisionMarkers()

--- a/src/twist_controller.yaml
+++ b/src/twist_controller.yaml
@@ -2,7 +2,7 @@ moveit_twist_controller:
   free_angle:
     type: string
     default_value: ""
-    description: "Axis where the actual rotation is free. -1 means no free angle."
+    description: "Axis where the actual rotation is free. Empty string means no free angle."
     read_only: true
     validation:
       one_of<>: [["","x","y","z"]]

--- a/src/twist_controller.yaml
+++ b/src/twist_controller.yaml
@@ -7,14 +7,6 @@ moveit_twist_controller:
     validation:
       one_of<>: [["","x","y","z"]]
 
-  gripper_joint_name:
-    type: string
-    default_value: "gripper_servo_joint"
-    description: "Name of the gripper joint in the urdf"
-    read_only: true
-    validation:
-      not_empty<>: []
-
   chained_controller:
     type: string
     default_value: ""
@@ -72,18 +64,8 @@ moveit_twist_controller:
   cmd_timeout:
       type: double
       default_value: 0.25
-      description: "Timeout in seconds after which twist and gripper velocity commands are zeroed if no new message arrives."
+      description: "Timeout in seconds after which twist commands are zeroed if no new message arrives."
       read_only: false
       validation:
         gt<>: 0.0
-
-  gripper_cmd_mode:
-      type: string
-      default_value: "velocity"
-      description: "Mode of the gripper. 'velocity' or 'position'."
-      read_only: false
-      validation:
-        one_of<>: [ [ "velocity", "position" ] ]
-
-
 

--- a/test/test_moveit_twist_controller_params.yaml
+++ b/test/test_moveit_twist_controller_params.yaml
@@ -2,6 +2,5 @@ test_moveit_twist_controller:
   ros__parameters:
 
     free_angle: ""
-    gripper_joint_name: "gripper_servo_joint"
     group_name: "arm_group"
     reject_if_velocity_limits_violated: false


### PR DESCRIPTION
## Summary 

Gripper handling now lives in the standalone `gripper_position_effort_controller/GripperPositionEffortController` (in [hector_ros_controllers](https://github.com/tu-darmstadt-ros-pkg/hector_ros_controllers)), so this package can drop its embedded gripper logic and stay focused on end-effector twist control.

## Changes
- Remove `GripperVelCommand`, `updateGripper()`, `loadGripperJointLimits()`, gripper buffers/limits/subscriptions, and the gripper position-command interface claim (avoids conflict with the new gripper controller at activation).
- Drop the `gripper_joint_name` and `gripper_cmd_mode` parameters and the corresponding `on_set_parameters` validator.
- Remove the now-unused `InverseKinematics::getJointLimits()` helper.
- README: drop gripper docs, add a short **Related Controllers** section pointing to `GripperPositionEffortController` and `safety_position_controller/SafetyPositionController`.
