### PR TITLE
Make scalar parameters dynamically updatable

### DIFF
--- a/src/twist_controller.cpp
+++ b/src/twist_controller.cpp
@@ -264,6 +264,9 @@ controller_interface::return_type MoveitTwistController::update( const rclcpp::T
     return controller_interface::return_type::OK;
   }
 
+  // Refresh runtime-updatable parameters (non-blocking, RT-safe)
+  param_listener_->try_update_params( params_ );
+
   // Retrieve current joint states from the hardware (read from state_interfaces_)
   for ( size_t i = 0; i < joint_names_.size(); ++i ) {
     if ( !getState( current_joint_angles_[i], joint_names_[i], "position" ) ) {

--- a/src/twist_controller.yaml
+++ b/src/twist_controller.yaml
@@ -33,7 +33,7 @@ moveit_twist_controller:
       type: double
       default_value: 5.0
       description: "Timeout for loading the robot description and robot_description_semantic in seconds."
-      read_only: false
+      read_only: true
       validation:
         gt<>: 0.0
 


### PR DESCRIPTION
Previously `params_` was only fetched once in `on_configure`, so runtime `ros2 param set` changes to non-read-only parameters had no effect.

This adds a non-blocking, RT-safe refresh at the top of `update()`:

```cpp
param_listener_->try_update_params( params_ );
